### PR TITLE
Unbreak build on -CURRENT after r222167

### DIFF
--- a/sys/fs/pefs/pefs_vfsops.c
+++ b/sys/fs/pefs/pefs_vfsops.c
@@ -406,11 +406,11 @@ pefs_vget(struct mount *mp, ino_t ino, int flags, struct vnode **vpp)
 }
 
 static int
-pefs_fhtovp(struct mount *mp, struct fid *fidp, struct vnode **vpp)
+pefs_fhtovp(struct mount *mp, struct fid *fidp, int flags, struct vnode **vpp)
 {
 	int error;
 
-	error = VFS_FHTOVP(VFS_TO_PEFS(mp)->pm_lowervfs, fidp, vpp);
+	error = VFS_FHTOVP(VFS_TO_PEFS(mp)->pm_lowervfs, fidp, LK_EXCLUSIVE, vpp);
 	if (error != 0)
 		return (error);
 


### PR DESCRIPTION
Added lock flags argument to the VFS_FHTOVP().
This patch only adds the flag.  It does not change
pefs to use it and pefs specifies LK_EXCLUSIVE, so
file system semantics are not changed
