### PR TITLE
Workaround for a broken bzero() used by sshd

### DIFF
--- a/lib/libpam/modules/pam_pefs/pam_pefs.c
+++ b/lib/libpam/modules/pam_pefs/pam_pefs.c
@@ -84,6 +84,13 @@ __FBSDID("$FreeBSD$");
 
 static int pam_pefs_debug;
 
+/*
+ * bzero() used by sshd is known to overrun the size. Use memset() as a workaround.
+ */
+void bzero(void * ptr, size_t size) {
+	memset(ptr, 0, size);
+}
+
 void
 pefs_warn(const char *fmt, ...)
 {


### PR DESCRIPTION
This makes pam_pefs.so work better with sshd (part 1 of 2).
