### PR TITLE
pam_pefs: allow symlinks in homedir.

### DIFF
--- a/lib/libpam/modules/pam_pefs/pam_pefs.c
+++ b/lib/libpam/modules/pam_pefs/pam_pefs.c
@@ -1,6 +1,7 @@
 /*-
  * Copyright (c) 2003 Networks Associates Technology, Inc.
  * Copyright (c) 2009 Gleb Kurtsou <gleb@FreeBSD.org>
+ * Copyright (c) 2011,2015 David Naylor <dbn@FreeBSD.org>
  * All rights reserved.
  *
  * This software was developed for the FreeBSD Project by ThinkSec AS and
@@ -279,13 +280,17 @@ static int
 pam_pefs_checkfs(const char *homedir)
 {
 	char fsroot[MAXPATHLEN];
-	int error;
+	char abshomedir[MAXPATHLEN];
 
-	error = pefs_getfsroot(homedir, 0, fsroot, sizeof(fsroot));
-	if (error != 0) {
-		pefs_warn("file system is not mounted: %s", homedir);
+	if (realpath(homedir, abshomedir) == NULL) {
+		pefs_warn("unable to resulve home dir: %s", homedir);
 		return (PAM_USER_UNKNOWN);
-	} if (strcmp(fsroot, homedir) != 0) {
+	}
+	if (pefs_getfsroot(abshomedir, 0, fsroot, sizeof(fsroot)) != 0) {
+		pefs_warn("file system is not mounted: %s", abshomedir);
+		return (PAM_USER_UNKNOWN);
+	}
+	if (strcmp(fsroot, abshomedir) != 0) {
 		pefs_warn("file system is not mounted on home dir: %s", fsroot);
 		return (PAM_USER_UNKNOWN);
 	}

--- a/lib/libpam/modules/pam_pefs/pam_pefs.c
+++ b/lib/libpam/modules/pam_pefs/pam_pefs.c
@@ -1,7 +1,7 @@
 /*-
  * Copyright (c) 2003 Networks Associates Technology, Inc.
  * Copyright (c) 2009 Gleb Kurtsou <gleb@FreeBSD.org>
- * Copyright (c) 2011,2015 David Naylor <dbn@FreeBSD.org>
+ * Copyright (c) 2011 David Naylor <dbn@FreeBSD.org>
  * All rights reserved.
  *
  * This software was developed for the FreeBSD Project by ThinkSec AS and
@@ -283,8 +283,7 @@ pam_pefs_checkfs(const char *homedir)
 	char abshomedir[MAXPATHLEN];
 
 	if (realpath(homedir, abshomedir) == NULL) {
-		pefs_warn("unable to resulve home dir: %s", homedir);
-		return (PAM_USER_UNKNOWN);
+		strncpy(abshomedir, homedir, sizeof(abshomedir));
 	}
 	if (pefs_getfsroot(abshomedir, 0, fsroot, sizeof(fsroot)) != 0) {
 		pefs_warn("file system is not mounted: %s", abshomedir);


### PR DESCRIPTION
pefs_getfsroot() returns a "real" path however if a user's home directory
includes a symlink (for example /home->/usr/local/home) then the
pam_pefs_checkfs() fails as struct passwd.pw_dir will not be a "real" path.

Convert struct passwd.pw_dir into a "real" path for comparison against
pefs_getfsroot() using realpath(3).
