### PR TITLE
pam_pefs: add shared memory support

### DIFF
--- a/lib/libpam/modules/pam_pefs/pam_pefs.c
+++ b/lib/libpam/modules/pam_pefs/pam_pefs.c
@@ -405,15 +405,15 @@ pam_pefs_store_key(pam_handle_t *pamh, struct pefs_keychain_head *kch)
 			sprintf(id_hex, "%#.*x", (int)(sizeof(int) * 2), shmid);
 			pam_setenv(pamh, PAM_PEFS_KEYS, id_hex, 1);
 			memcpy(shmdata, &(TAILQ_FIRST(kch)->kc_key), sizeof(struct pefs_xkey));
-			memset(&(TAILQ_FIRST(kch)->kc_key), 0, sizeof(struct pefs_xkey));
-		}
-
-		if (id_hex != NULL) {
 			free(id_hex);
 		}
+
 		if (shmdata != (void *)-1) {
 			shmdt(shmdata);
 		}
+
+		pefs_keychain_free(kch);
+		free(kch);
 	}
 }
 
@@ -438,13 +438,9 @@ pam_pefs_retrieve_key(pam_handle_t *pamh, struct pefs_keychain_head **kch)
 			TAILQ_INIT(*kch);
 			TAILQ_INSERT_HEAD(*kch, entry, kc_entry);
 			memcpy(&(TAILQ_FIRST(*kch)->kc_key), shmdata, sizeof(struct pefs_xkey));
+			shmdt(shmdata);
 			status = PAM_SUCCESS;
 		}
-
-		if (shmdata != (void *)-1) {
-			shmdt(shmdata);
-		}
-
 	}
 
 	return status;

--- a/lib/libpam/modules/pam_pefs/pam_pefs.c
+++ b/lib/libpam/modules/pam_pefs/pam_pefs.c
@@ -419,6 +419,9 @@ pam_pefs_store_key(pam_handle_t *pamh, struct pefs_keychain_head *kch)
 			TAILQ_FOREACH(kc, kch, kc_entry)
 				memcpy(shmkey++, &(kc->kc_key), sizeof(*shmkey));
 		}
+		else {
+			pefs_warn("failed to allocate shared memory for key");
+		}
 
 		if (shmdata != (void *)-1) {
 			shmdt(shmdata);
@@ -469,6 +472,10 @@ pam_pefs_retrieve_key(pam_handle_t *pamh, struct pefs_keychain_head **kch)
 			}
 		}
 
+		if (status != PAM_SUCCESS) {
+			pefs_warn("failed to retrieve key from shared memory");
+		}
+
 		if (shmdata != (void *)-1) {
 			shmdt(shmdata);
 		}
@@ -496,6 +503,9 @@ pam_pefs_release_key(pam_handle_t *pamh, struct pefs_keychain_head *kch)
 			    + (sizeof(struct pefs_xkey) * keycnt);
 			memset(shmdata, 0, shmsize);
 			shmdt(shmdata);
+		}
+		else {
+			pefs_warn("failed to release shared memory for key");
 		}
 
 		if (shmid > 0) {


### PR DESCRIPTION
Add the ability to use shared memory to store the key between the pam_sm_authenticate() and pam_sm_open_session() functions.  This is required if a program fork()s between those functions.  The key is shared for a minimal amount of time, being freed before pam_sm_open_session() finishes.  

sshd(8) was the motivator for implementing this change (based on other pam modules that also need to share data between the two pam functions, I forget which one now).  In my setup I use two factor authentication: public/private key and then the pefs decryption key.  
