### PR TITLE
Switch from using va_gen to va_filerev since its actually the correct attribute for this purpose

### DIFF
--- a/sys/fs/pefs/pefs_dircache.c
+++ b/sys/fs/pefs/pefs_dircache.c
@@ -318,7 +318,7 @@ pefs_dircache_purge(struct pefs_dircache *pd)
 
 	// ASSERT_VOP_ELOCKED
 	mtx_lock(&pd->pd_mtx);
-	atomic_store_rel_long(&pd->pd_gen, 0);
+	atomic_store_rel_long(&pd->pd_filerev, 0);
 	LIST_FOREACH_SAFE(pde, &pd->pd_activehead, pde_dir_entry, tmp) {
 		dircache_entry_expire_locked(pde);
 	}
@@ -336,7 +336,7 @@ pefs_dircache_expire(struct pefs_dircache_entry *pde, u_int dflags)
 	if (pd == NULL)
 		return;
 	mtx_lock(&pd->pd_mtx);
-	atomic_store_rel_long(&pd->pd_gen, 0);
+	atomic_store_rel_long(&pd->pd_filerev, 0);
 	dircache_retry_clear(pd);
 	if (pde->pde_dircache != NULL) {
 		dircache_entry_expire_locked(pde);

--- a/sys/fs/pefs/pefs_dircache.c
+++ b/sys/fs/pefs/pefs_dircache.c
@@ -318,6 +318,7 @@ pefs_dircache_purge(struct pefs_dircache *pd)
 
 	// ASSERT_VOP_ELOCKED
 	mtx_lock(&pd->pd_mtx);
+	atomic_store_rel_long(&pd->pd_gen, 0);
 	atomic_store_rel_64(&pd->pd_filerev, 0);
 	LIST_FOREACH_SAFE(pde, &pd->pd_activehead, pde_dir_entry, tmp) {
 		dircache_entry_expire_locked(pde);
@@ -336,6 +337,7 @@ pefs_dircache_expire(struct pefs_dircache_entry *pde, u_int dflags)
 	if (pd == NULL)
 		return;
 	mtx_lock(&pd->pd_mtx);
+	atomic_store_rel_long(&pd->pd_gen, 0);
 	atomic_store_rel_64(&pd->pd_filerev, 0);
 	dircache_retry_clear(pd);
 	if (pde->pde_dircache != NULL) {

--- a/sys/fs/pefs/pefs_dircache.c
+++ b/sys/fs/pefs/pefs_dircache.c
@@ -318,7 +318,7 @@ pefs_dircache_purge(struct pefs_dircache *pd)
 
 	// ASSERT_VOP_ELOCKED
 	mtx_lock(&pd->pd_mtx);
-	atomic_store_rel_long(&pd->pd_filerev, 0);
+	atomic_store_rel_64(&pd->pd_filerev, 0);
 	LIST_FOREACH_SAFE(pde, &pd->pd_activehead, pde_dir_entry, tmp) {
 		dircache_entry_expire_locked(pde);
 	}
@@ -336,7 +336,7 @@ pefs_dircache_expire(struct pefs_dircache_entry *pde, u_int dflags)
 	if (pd == NULL)
 		return;
 	mtx_lock(&pd->pd_mtx);
-	atomic_store_rel_long(&pd->pd_filerev, 0);
+	atomic_store_rel_64(&pd->pd_filerev, 0);
 	dircache_retry_clear(pd);
 	if (pde->pde_dircache != NULL) {
 		dircache_entry_expire_locked(pde);

--- a/sys/fs/pefs/pefs_dircache.h
+++ b/sys/fs/pefs/pefs_dircache.h
@@ -42,7 +42,8 @@ struct pefs_dircache {
 	struct mtx			pd_mtx;
 	struct pefs_dircache_listhead	pd_activehead;
 	struct pefs_dircache_listhead	pd_stalehead;
-	volatile u_quad_t               pd_filerev;
+	volatile u_long					pd_gen;
+	volatile u_quad_t				pd_filerev;
 	struct pefs_dircache_pool	*pd_pool;
 	struct pefs_dircache_entry	*pd_retry[PEFS_DIRCACHE_RETRY_COUNT];
 };
@@ -89,14 +90,17 @@ void	pefs_dircache_expire_encname(struct pefs_dircache *pd,
 void	pefs_dircache_gc(struct pefs_dircache *pd);
 
 static __inline int
-pefs_dircache_valid(struct pefs_dircache *pd, u_quad_t filerev)
+pefs_dircache_valid(struct pefs_dircache *pd, u_long gen, u_quad_t filerev)
 {
+	u_long pd_gen;
 	u_quad_t pd_filerev;
 
-	if (filerev == 0)
+	if (filerev == 0 && gen == 0)
 		return 0;
+
+	pd_gen = atomic_load_acq_long(&pd->pd_gen);
 	pd_filerev = atomic_load_acq_64(&pd->pd_filerev);
-	return (filerev == pd_filerev);
+	return ((filerev == pd_filerev || filerev == 0) && (gen == pd_gen || gen == 0));
 }
 
 static __inline void
@@ -105,8 +109,9 @@ pefs_dircache_beginupdate(struct pefs_dircache *pd)
 }
 
 static __inline void
-pefs_dircache_endupdate(struct pefs_dircache *pd, u_quad_t filerev)
+pefs_dircache_endupdate(struct pefs_dircache *pd, u_long gen, u_quad_t filerev)
 {
+	atomic_store_rel_long(&pd->pd_gen, gen);
 	atomic_store_rel_64(&pd->pd_filerev, filerev);
 }
 

--- a/sys/fs/pefs/pefs_dircache.h
+++ b/sys/fs/pefs/pefs_dircache.h
@@ -42,7 +42,7 @@ struct pefs_dircache {
 	struct mtx			pd_mtx;
 	struct pefs_dircache_listhead	pd_activehead;
 	struct pefs_dircache_listhead	pd_stalehead;
-	volatile u_long			pd_gen;
+	volatile u_quad_t               pd_filerev;
 	struct pefs_dircache_pool	*pd_pool;
 	struct pefs_dircache_entry	*pd_retry[PEFS_DIRCACHE_RETRY_COUNT];
 };
@@ -89,14 +89,14 @@ void	pefs_dircache_expire_encname(struct pefs_dircache *pd,
 void	pefs_dircache_gc(struct pefs_dircache *pd);
 
 static __inline int
-pefs_dircache_valid(struct pefs_dircache *pd, u_long gen)
+pefs_dircache_valid(struct pefs_dircache *pd, u_quad_t filerev)
 {
-	u_long pd_gen;
+	u_quad_t pd_filerev;
 
-	if (gen == 0)
+	if (filerev == 0)
 		return 0;
-	pd_gen = atomic_load_acq_long(&pd->pd_gen);
-	return (gen == pd_gen);
+	pd_filerev = atomic_load_acq_long(&pd->pd_filerev);
+	return (filerev == pd_filerev);
 }
 
 static __inline void
@@ -105,9 +105,9 @@ pefs_dircache_beginupdate(struct pefs_dircache *pd)
 }
 
 static __inline void
-pefs_dircache_endupdate(struct pefs_dircache *pd, u_long gen)
+pefs_dircache_endupdate(struct pefs_dircache *pd, u_quad_t filerev)
 {
-	atomic_store_rel_long(&pd->pd_gen, gen);
+	atomic_store_rel_long(&pd->pd_filerev, filerev);
 }
 
 static __inline void

--- a/sys/fs/pefs/pefs_dircache.h
+++ b/sys/fs/pefs/pefs_dircache.h
@@ -95,7 +95,7 @@ pefs_dircache_valid(struct pefs_dircache *pd, u_quad_t filerev)
 
 	if (filerev == 0)
 		return 0;
-	pd_filerev = atomic_load_acq_long(&pd->pd_filerev);
+	pd_filerev = atomic_load_acq_64(&pd->pd_filerev);
 	return (filerev == pd_filerev);
 }
 
@@ -107,7 +107,7 @@ pefs_dircache_beginupdate(struct pefs_dircache *pd)
 static __inline void
 pefs_dircache_endupdate(struct pefs_dircache *pd, u_quad_t filerev)
 {
-	atomic_store_rel_long(&pd->pd_filerev, filerev);
+	atomic_store_rel_64(&pd->pd_filerev, filerev);
 }
 
 static __inline void


### PR DESCRIPTION
Fixes #51

OpenZFS in FreeBSD 13.1 and up no no longer incorrectly updates va_gen when the file or directory is modified. This means that is no longer a reliable source to base a dircache invalidation on. Instead we should use va_filerev for that, which is based on the same value that va_gen (incorrectly) used to be based on prior to 13.1.